### PR TITLE
Allow dynamic properties

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -47,6 +47,7 @@ use MailchimpMarketing\Api\TemplateFoldersApi;
 use MailchimpMarketing\Api\TemplatesApi;
 use MailchimpMarketing\Api\VerifiedDomainsApi;
 
+#[AllowDynamicProperties]
 class Configuration
 {
     private static $defaultConfiguration;


### PR DESCRIPTION
Dodao sam atribut `#[AllowDynamicProperties` u klasi `Configuration` zato sto je ona parent klasa `ApiClient` klasi koja baca deprecation logove. 